### PR TITLE
Add Webots RL training support

### DIFF
--- a/RL_Agent.py
+++ b/RL_Agent.py
@@ -22,9 +22,10 @@ class RQNetwork(nn.Module):
 
 
 class RQNAgent:
-    def __init__(self, state_dim, action_dim):
+    def __init__(self, state_dim, action_dim, num_motors=2):
         self.state_dim = state_dim
-        self.action_dim = action_dim  # 이산 행동 개수 (예: 27)
+        self.action_dim = action_dim  # 이산 행동 개수 (예: 9)
+        self.num_motors = num_motors
         self.memory = deque(maxlen=100000)
         self.batch_size = 64
         self.gamma = 0.99
@@ -42,14 +43,12 @@ class RQNAgent:
         self.update_target_network()
 
         # 행동 후보 맵핑 (이산→연속 속도)
-        # 예: 속도 후보 = [-1.0, 0.0, +1.0] 
-        # 조합으로 총 27개 행동 매핑
+        # 예: 속도 후보 = [-1.0, 0.0, +1.0]
+        # Motor 1,3 두 축만 사용하므로 조합은 3^2 = 9개
+        from itertools import product
         self.vel_candidates = [-1.0, 0.0, 1.0]
-        self.discrete_to_vel = []
-        for v1 in self.vel_candidates:
-            for v2 in self.vel_candidates:
-                for v3 in self.vel_candidates:
-                    self.discrete_to_vel.append([v1, v2, v3])
+        self.discrete_to_vel = [list(p) for p in product(self.vel_candidates, repeat=self.num_motors)]
+        assert len(self.discrete_to_vel) == self.action_dim, "action_dim과 행동 매핑 수가 일치하지 않습니다."
 
     def update_target_network(self):
         self.target_model.load_state_dict(self.model.state_dict())

--- a/balance_env.py
+++ b/balance_env.py
@@ -1,0 +1,87 @@
+"""Webots 환경 관리 모듈.
+
+이 모듈은 Supervisor 컨트롤러로 동작하여 공 위치와 모터 상태를
+관측하고, 강화학습 에이전트와의 인터페이스를 제공합니다.
+"""
+
+from controller import Supervisor
+
+
+class BalanceBotEnv:
+    def __init__(self, max_steps=1000):
+        self.robot = Supervisor()
+        self.time_step = int(self.robot.getBasicTimeStep())
+
+        # 모터 디바이스 설정 (motor2는 사용하지 않음)
+        self.motor1 = self.robot.getDevice('motor 1')
+        self.motor2 = self.robot.getDevice('motor 2')
+        self.motor3 = self.robot.getDevice('motor 3')
+
+        # 위치 제어 비활성화 후 속도 제어용으로 설정
+        for m in (self.motor1, self.motor2, self.motor3):
+            m.setPosition(float('inf'))
+            m.setVelocity(0.0)
+
+        # 공 노드
+        self.ball_node = self.robot.getFromDef('Ball')
+        self.translation_field = self.ball_node.getField('translation')
+
+        # 모터 각도 필드
+        self.joint1_sensor = self.motor1.getPositionSensor()
+        self.joint3_sensor = self.motor3.getPositionSensor()
+        for s in (self.joint1_sensor, self.joint3_sensor):
+            s.enable(self.time_step)
+
+        self.prev_ball_pos = [0.0, 0.0]
+        self.max_steps = max_steps
+        self.step_count = 0
+
+    def get_state(self):
+        pos = self.translation_field.getSFVec3f()
+        x, y = pos[0], pos[1]
+        vx = (x - self.prev_ball_pos[0]) / (self.time_step / 1000.0)
+        vy = (y - self.prev_ball_pos[1]) / (self.time_step / 1000.0)
+
+        self.prev_ball_pos = [x, y]
+
+        theta1 = self.joint1_sensor.getValue()
+        theta3 = self.joint3_sensor.getValue()
+
+        return [x, y, vx, vy, theta1, theta3]
+
+    def compute_reward(self, state):
+        # 간단한 보상 설계
+        x, y, vx, vy, _, _ = state
+        alpha = 1.0
+        beta = 0.1
+        gamma = 1.0
+        distance_penalty = -alpha * (x ** 2 + y ** 2)
+        alive_bonus = beta
+        static_penalty = -gamma if abs(vx) < 1e-3 and abs(vy) < 1e-3 else 0.0
+        return distance_penalty + alive_bonus + static_penalty
+
+    def step(self, action):
+        """액션은 [v1, v3] 형태의 모터 속도 리스트."""
+        self.motor1.setVelocity(action[0])
+        self.motor3.setVelocity(action[1])
+
+        self.robot.step(self.time_step)
+
+        state = self.get_state()
+        reward = self.compute_reward(state)
+
+        done = self.translation_field.getSFVec3f()[2] < 0.09
+        self.step_count += 1
+        if self.step_count >= self.max_steps:
+            done = True
+
+        return state, reward, done
+
+    def reset(self):
+        self.robot.simulationReset()
+        self.robot.step(self.time_step)
+        pos = self.translation_field.getSFVec3f()
+        self.prev_ball_pos = [pos[0], pos[1]]
+        self.step_count = 0
+        return self.get_state()
+

--- a/train.py
+++ b/train.py
@@ -1,0 +1,54 @@
+"""강화학습 학습 루프 스크립트.
+
+Webots 환경을 초기화하고 RQN 또는 SAC 에이전트를 사용해
+공 균형 제어 정책을 학습한다.
+"""
+
+import argparse
+
+from balance_env import BalanceBotEnv
+from RL_Agent import RQNAgent, SACAgent
+
+
+def train(agent_type="rqn", episodes=10):
+    env = BalanceBotEnv()
+    state_dim = 6
+
+    if agent_type == "rqn":
+        action_dim = 9
+        agent = RQNAgent(state_dim, action_dim)
+        action_mapper = agent.map_discrete_to_velocity
+    else:
+        action_dim = 2
+        agent = SACAgent(state_dim, action_dim)
+        action_mapper = lambda a: a
+
+    for ep in range(episodes):
+        state = env.reset()
+        done = False
+        while not done:
+            if agent_type == "rqn":
+                action_idx = agent.select_action(state)
+                action = action_mapper(action_idx)
+            else:
+                action = agent.select_action(state)
+
+            next_state, reward, done = env.step(action)
+
+            if agent_type == "rqn":
+                agent.store_transition(state, action_idx, reward, next_state, done)
+            else:
+                agent.store_transition(state, action, reward, next_state, done)
+
+            agent.train()
+            state = next_state
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent", choices=["rqn", "sac"], default="rqn")
+    parser.add_argument("--episodes", type=int, default=10)
+    args = parser.parse_args()
+
+    train(agent_type=args.agent, episodes=args.episodes)
+


### PR DESCRIPTION
## Summary
- add generic RQNAgent action mapping for 2 motors
- implement `BalanceBotEnv` to control Webots via Supervisor
- create `train.py` to run RQN or SAC on the environment

## Testing
- `python -m py_compile RL_Agent.py balance_env.py train.py`

------
https://chatgpt.com/codex/tasks/task_e_684168f89f548331820c1c4a7b47b2f4